### PR TITLE
Match current CP style for addon header

### DIFF
--- a/Logbook/resources/views/index.blade.php
+++ b/Logbook/resources/views/index.blade.php
@@ -3,10 +3,8 @@
 @section('content')
 <div id="logbook">
 
-    <div class="card sticky flat-bottom">
-        <div class="head">
-            <h1>Logbook</h1>
-        </div>
+    <div class="flexy mb-1">
+        <h1 class="fill">Logbook</h1>
     </div>
 
     @if (count($files))


### PR DESCRIPTION
Currently:

![](https://than.d.pr/TmqmhW.png)

With this fix:

![](https://than.d.pr/5VVMDm.png)