### PR TITLE
Allow rap2hpoutre/laravel-log-viewer ^3.0 (Laravel 13 support + RCE fix)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "homepage": "https://github.com/aryehraber/statamic-logbook",
     "license": "MIT",
     "require": {
-        "rap2hpoutre/laravel-log-viewer": "^2.3.0",
+        "rap2hpoutre/laravel-log-viewer": "^2.3 || ^3.0",
         "statamic/cms": "^6.0"
     },
     "autoload": {


### PR DESCRIPTION
Closes #26.

Widens the `rap2hpoutre/laravel-log-viewer` constraint from `^2.3.0` to `^2.3 || ^3.0` so Logbook can be installed alongside log-viewer v3.x.

## Why

- **Unblocks Laravel 13** — log-viewer v2.x caps at Laravel 12 (`illuminate/support ^6|...|^12`). Statamic 6 supports Laravel 12 *and* 13, but the current `^2.3.0` pin forces Logbook users to stay on 12.
- **Pulls in a security fix** — log-viewer v3.1.0 fixes insecure deserialization (RCE) and path traversal via query parameters (rap2hpoutre/laravel-log-viewer#320). Users on the pinned v2.x branch don't get this.

## Why this is safe

`LogbookController` only uses `setFile()`, `pathToLogFile()`, `all()`, `getFiles()` and `getFileName()` from `LaravelLogViewer`. None of these changed between v2.5.0 and v3.1.0 — the diff is just composer constraints, the security fix, and a small refactor in two files.

## Testing

Running this on a Statamic 6.19 / Laravel 13 project. Logbook utility loads, lists log files, displays and deletes them as expected. Verified both ways:
- via a temporary inline alias (`v3.1.0 as v2.5.0`) before this change